### PR TITLE
a tag の href が存在するとコピペできなくなるので修正

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -4,13 +4,35 @@ import gfm from 'remark-gfm';
 import rehype from 'remark-rehype';
 import stringify from 'rehype-stringify';
 import highlight from 'rehype-highlight';
+import { visit } from 'unist-util-visit';
+
+const removeHttpLinks = () => (tree: any) => {
+	visit(tree, 'element', (node: any, _, parent: any) => {
+		if (
+			node.tagName === 'a' &&
+			node.properties.href &&
+			(node.properties.href.startsWith('http://') || node.properties.href.startsWith('https://'))
+		) {
+			parent.children.splice(parent.children.indexOf(node), 1, {
+				type: 'element',
+				tagName: 'span',
+				properties: {
+					onClick: `window.open('${node.properties.href}', '_blank'); return false;`,
+					style: 'cursor: pointer;text-decoration: underline;'
+				},
+				children: node.children
+			});
+		}
+	});
+};
 
 const marked = remark()
 	.use(parse)
 	.use(rehype)
 	.use(stringify)
 	.use(highlight, { detect: true, subset: ['javascript'], ignoreMissing: true })
-	.use(gfm);
+	.use(gfm)
+	.use(removeHttpLinks);
 
 export const markdown = (
 	text: string,


### PR DESCRIPTION
https://github.com/himanushi/chat-code/issues/3

原因は不明だが、 a tag に href が存在するとテキスト選択ができなくなる。 onClick に変更し対策した。